### PR TITLE
Scenes states

### DIFF
--- a/SuperMarioBros-Nes/data.json
+++ b/SuperMarioBros-Nes/data.json
@@ -100,6 +100,10 @@
       "address": 206,
       "type": "|u1"
     },
+    "player_y_screen": {
+      "address": 181,
+      "type": "|i1"
+    },
     "powerstate": {
       "address": 1878,
       "type": ">d4"


### PR DESCRIPTION
Added player_y_screen, an int that allows the interpretation of player_y_pos

Based on https://datacrystal.tcrf.net/wiki/Super_Mario_Bros./RAM_map

Player vertical screen position
viewport = 1
above viewport = 0
anywhere below viewport is >1
(when falling down a pit this will increase up to 5)